### PR TITLE
appid windows 10

### DIFF
--- a/alert_windows.go
+++ b/alert_windows.go
@@ -5,11 +5,11 @@ package beeep
 import (
 	"path/filepath"
 
-	toast "gopkg.in/toast.v1"
+	"gopkg.in/toast.v1"
 )
 
 // Alert displays a desktop notification and plays a default system sound.
-func Alert(title, message, appIcon string) error {
+func Alert(appid, title, message, appIcon string) error {
 	var err error
 	iconPath := ""
 	if appIcon != "" {
@@ -18,7 +18,7 @@ func Alert(title, message, appIcon string) error {
 			return err
 		}
 	}
-	note := toastNotification(title, message, iconPath)
+	note := toastNotification(appid, title, message, iconPath)
 	note.Audio = toast.Default
 	return note.Push()
 }

--- a/notify_windows.go
+++ b/notify_windows.go
@@ -9,13 +9,13 @@ import (
 	"strconv"
 	"strings"
 
-	toast "gopkg.in/toast.v1"
+	"gopkg.in/toast.v1"
 )
 
 // Notify sends desktop notification.
-func Notify(title, message, appIcon string) error {
+func Notify(appid, title, message, appIcon string) error {
 	if isWindows10() {
-		return toastNotify(title, message, appIcon)
+		return toastNotify(appid, title, message, appIcon)
 	}
 	return msgNotify(title, message)
 }
@@ -29,7 +29,7 @@ func msgNotify(title, message string) error {
 	return cmd.Start()
 }
 
-func toastNotify(title, message, appIcon string) error {
+func toastNotify(appid, title, message, appIcon string) error {
 	var err error
 	iconPath := ""
 	if appIcon != "" {
@@ -38,14 +38,14 @@ func toastNotify(title, message, appIcon string) error {
 			return err
 		}
 	}
-	notification := toastNotification(title, message, iconPath)
+	notification := toastNotification(appid, title, message, iconPath)
 	return notification.Push()
 }
 
-func toastNotification(title, message, appIcon string) toast.Notification {
+func toastNotification(appID, title, message, appIcon string) toast.Notification {
 	// NOTE: a real appID is required since Windows 10 Fall Creator's Update,
 	// issue https://github.com/go-toast/toast/issues/9
-	appID := "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe"
+	//appID := "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe"
 	return toast.Notification{
 		AppID:   appID,
 		Title:   title,


### PR DESCRIPTION
As far as I see this library is forcing the use of the Powershell Appid.

I've made some changes that would allow us to pass the app AppId when calling the library. Not sure if I am missing something... for your review.

on the main go app we just define/discover the AppId we want to use and use it as a parameter.

err := beeep.Notify(appId, "title", "message", "icon")