### PR TITLE
Allow for notifications from any user.

### DIFF
--- a/alert_darwin.go
+++ b/alert_darwin.go
@@ -11,6 +11,6 @@ func Alert(title, message, appIcon string) error {
 		return err
 	}
 
-	cmd := exec.Command(osa, "-e", `display notification "`+message+`" with title "`+title+`" sound name "default"`)
+    cmd := exec.Command(osa, "-e", `tell application "System Events" to display notification "`+message+`" with title "`+title+`" sound name "default"`)
 	return cmd.Start()
 }


### PR DESCRIPTION
While using this library to fire notifications for a golang app (more specifically an osquery plugin) which runs as root, notifications wouldn't fire as root had no logged in session. Setting the osascript to tell application "System Events" made the alert popup on the currently logged in users screen.