### PR TITLE
Don't try to close the shared system-bus connection

### DIFF
--- a/notify_unix.go
+++ b/notify_unix.go
@@ -41,9 +41,6 @@ func Notify(title, message, appIcon string) error {
 	if err != nil {
 		return cmd()
 	}
-
-	defer conn.Close()
-
 	obj := conn.Object("org.freedesktop.Notifications", dbus.ObjectPath("/org/freedesktop/Notifications"))
 
 	call := obj.Call("org.freedesktop.Notifications.Notify", 0, "", uint32(0), appIcon, title, message, []string{}, map[string]dbus.Variant{}, int32(-1))


### PR DESCRIPTION
Closing the shared system-bus connection caused beeep to only ever be able to emit exactly
one notification via dbus, before falling back to notify-send for further
messages.

From the dbus documentation:

```
Close closes the connection ... This method must not be called on shared connections.
```