### PR TITLE
Use Run() instead of Start() to execute notification helpers

### DIFF
--- a/notify_unix.go
+++ b/notify_unix.go
@@ -25,7 +25,7 @@ func Notify(title, message, appIcon string) error {
 		}
 
 		c := exec.Command(send, title, message, "-i", appIcon)
-		return c.Start()
+		return c.Run()
 	}
 
 	knotify := func() error {
@@ -34,7 +34,7 @@ func Notify(title, message, appIcon string) error {
 			return err
 		}
 		c := exec.Command(send, "--title", title, "--passivepopup", message, "10", "--icon", appIcon)
-		return c.Start()
+		return c.Run()
 	}
 
 	conn, err := dbus.SessionBus()


### PR DESCRIPTION
Using Start() but not waiting for the command to complete will leave dangling
defunct processes that can't be cleaned up until its parent dies.

```
15660 pts/15   Z+     0:00 [notify-send] <defunct>
16139 pts/15   Z+     0:00 [notify-send] <defunct>
16644 pts/15   Z+     0:00 [notify-send] <defunct>
...
```

Run() will wait for the command to finish, but cleans up after itself.

Alternatively, we could launch Start() in a go-routine and Wait() for it, but that complicates the error handling.