### PR TITLE
beep_darwin: beep without requiring special system events permissions

### DIFF
--- a/beep_darwin.go
+++ b/beep_darwin.go
@@ -23,6 +23,6 @@ func Beep(freq float64, duration int) error {
 		return err
 	}
 
-	cmd := exec.Command(osa, "-e", `tell application "System Events" to beep`)
+	cmd := exec.Command(osa, "-e", `beep`)
 	return cmd.Run()
 }


### PR DESCRIPTION
```bash
$ osascript -e "tell application \"System Events\" to beep" 
```

raises
![image](https://user-images.githubusercontent.com/319826/73524627-ce9ed200-440d-11ea-8013-8dbf2b8d725b.png)

if user denies that there is an error:
```bash
36:40: execution error: Not authorised to send Apple events to System Events. (-1743)
```
and there is no beep.

On the other hand, a simpler:
```bash
$ osascript -e "beep" 
```
does not require any extra permissions and it makes mac beep without any prompts.