### PR TITLE
Remove unneeded profile execution

### DIFF
--- a/notify_windows.go
+++ b/notify_windows.go
@@ -102,7 +102,7 @@ func toastNotification(title, message, appIcon string) toast.Notification {
 
 func appID() string {
 	defID := "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe"
-	cmd := exec.Command("powershell", "Get-StartApps")
+	cmd := exec.Command("powershell", "-NoProfile", "Get-StartApps")
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
Hello there! I was working on a project of mine and came across some abnormal behavior using beeep's windows notify feature. Running a compiled binary using the beeep.Notify function I noticed that the system's PowerShell profile was being executed when it shouldn't have been. After some hunting, I figured out that beeep was using PowerShell commands for some functionality but without specifying the -NoProfile argument. As the goal of the line was to simply capture the output of the Get-StartApps command I figured it wouldn't hurt to add in the NoProfile arg and would prevent any unexpected outputs/behavior.