### PR TITLE
Fix Notify() signature in notify_unsupported.go

### DIFF
--- a/notify_unsupported.go
+++ b/notify_unsupported.go
@@ -4,6 +4,6 @@
 package beeep
 
 // Notify sends desktop notification.
-func Notify(title, message string) error {
+func Notify(title, message, appIcon string) error {
 	return ErrUnsupported
 }


### PR DESCRIPTION
The other versions all take a third appIcon argument but this version did not, breaking builds on platforms using this code path.

(This is the same fix as [this PR](https://github.com/gen2brain/beeep/pull/50) from last year, which I only discovered just now, but against a newer master branch)