### PR TITLE
Use unix versions on Illumos

### DIFF
--- a/alert_unix.go
+++ b/alert_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd || netbsd || openbsd
-// +build linux freebsd netbsd openbsd
+//go:build linux || freebsd || netbsd || openbsd || illumos
+// +build linux freebsd netbsd openbsd illumos
 
 package beeep
 

--- a/alert_unsupported.go
+++ b/alert_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux && !freebsd && !netbsd && !openbsd && !windows && !darwin && !js
-// +build !linux,!freebsd,!netbsd,!openbsd,!windows,!darwin,!js
+//go:build !linux && !freebsd && !netbsd && !openbsd && !windows && !darwin && !illumos && !js
+// +build !linux,!freebsd,!netbsd,!openbsd,!windows,!darwin,!illumos,!js
 
 package beeep
 

--- a/beep_unix.go
+++ b/beep_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd || netbsd || openbsd
-// +build linux freebsd netbsd openbsd
+//go:build linux || freebsd || netbsd || openbsd || illumos
+// +build linux freebsd netbsd openbsd illumos
 
 package beeep
 

--- a/beep_unsupported.go
+++ b/beep_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux && !freebsd && !netbsd && !openbsd && !windows && !darwin && !js
-// +build !linux,!freebsd,!netbsd,!openbsd,!windows,!darwin,!js
+//go:build !linux && !freebsd && !netbsd && !openbsd && !windows && !darwin && !illumos && !js
+// +build !linux,!freebsd,!netbsd,!openbsd,!windows,!darwin,!illumos,!js
 
 package beeep
 

--- a/notify_unix_nodbus.go
+++ b/notify_unix_nodbus.go
@@ -1,5 +1,5 @@
-//go:build (linux && nodbus) || (freebsd && nodbus) || (netbsd && nodbus) || (openbsd && nodbus)
-// +build linux,nodbus freebsd,nodbus netbsd,nodbus openbsd,nodbus
+//go:build (linux && nodbus) || (freebsd && nodbus) || (netbsd && nodbus) || (openbsd && nodbus) || illumos
+// +build linux,nodbus freebsd,nodbus netbsd,nodbus openbsd,nodbus illumos
 
 package beeep
 

--- a/notify_unsupported.go
+++ b/notify_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux && !freebsd && !netbsd && !openbsd && !windows && !darwin && !js
-// +build !linux,!freebsd,!netbsd,!openbsd,!windows,!darwin,!js
+//go:build !linux && !freebsd && !netbsd && !openbsd && !windows && !darwin && !illumos && !js
+// +build !linux,!freebsd,!netbsd,!openbsd,!windows,!darwin,!illumos,!js
 
 package beeep
 


### PR DESCRIPTION
Illumos is the OpenSolaris-based OS core of OpenIndiana, SmartOS, etc.

Did not enable the dbus path because:

    go: downloading github.com/godbus/dbus/v5 v5.1.0
    # github.com/godbus/dbus/v5
    ../../go/pkg/mod/github.com/godbus/dbus/v5@v5.1.0/conn.go:147:17: undefined: getSystemBusPlatformAddress
    ../../go/pkg/mod/github.com/godbus/dbus/v5@v5.1.0/conn.go:174:14: undefined: getSystemBusPlatformAddress