### PR TITLE
🐛 Fix the baloonNotify not hiding the tray after displaying a message

### DIFF
--- a/notify_windows.go
+++ b/notify_windows.go
@@ -79,9 +79,11 @@ func baloonNotify(title, message, appIcon string, bigIcon bool) error {
 	}
 
 	go func() {
-		tray.Run()
+		go func() {
+			_ = tray.Run()
+		}()
 		time.Sleep(3 * time.Second)
-		tray.Stop()
+		_ = tray.Stop()
 	}()
 
 	return tray.ShowMessage(title, message, bigIcon)


### PR DESCRIPTION
Calling the `tray.Run()` method directly causes blocking, preventing the subsequent `time.Sleep` and `tray.Stop` methods from executing!

https://github.com/gen2brain/beeep/blob/5559732623e024336aab99ab3eadfbf79d3c220b/notify_windows.go#L81-L87

Close #58  