### PR TITLE
Use 'display notification' with sound parameter instead of 'System Events' on macOS

### DIFF
--- a/alert_darwin.go
+++ b/alert_darwin.go
@@ -15,7 +15,7 @@ func Alert(title, message, appIcon string) error {
 		return err
 	}
 
-	script := fmt.Sprintf("tell application \"System Events\" to display notification %q with title %q sound name \"default\"", message, title)
+	script := fmt.Sprintf(`display notification "%s" with title "%s" sound name "default"`, message, title)
 	cmd := exec.Command(osa, "-e", script)
 	return cmd.Run()
 }


### PR DESCRIPTION
While not being an Apple Script expert, I am under the impression that every time the caller/its parent process's fingerprint changes one needs to allow it to call `System Events` (again).

That does not seem to be necessary with `display notification`. 
And as this also got a parameter for `sound` that might be the better approach?

Regarding backwards compatibility: this is mentioned in some doc from Apple that dates back by at least 6 years. So I assume this should cover all scenarios: https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/DisplayNotifications.html

WDYT? 