### PR TITLE
re-fix quoting in macOS alert

### DIFF
--- a/alert_darwin.go
+++ b/alert_darwin.go
@@ -15,7 +15,7 @@ func Alert(title, message, appIcon string) error {
 		return err
 	}
 
-	script := fmt.Sprintf(`display notification "%s" with title "%s" sound name "default"`, message, title)
+	script := fmt.Sprintf("display notification %q with title %q sound name \"default\"", message, title)
 	cmd := exec.Command(osa, "-e", script)
 	return cmd.Run()
 }


### PR DESCRIPTION
The pr https://github.com/gen2brain/beeep/pull/60 have reintroduced quoting issue fixed by https://github.com/gen2brain/beeep/pull/49 :)

Also, i think it's safer to keep consistency between methods, and as you can see, both double quotes and `%q` are already used in [notify_darwin.go](https://github.com/gen2brain/beeep/blob/master/notify_darwin.go)