### PR TITLE
Support using system icons with semantics (Linux)

### DIFF
--- a/beeep.go
+++ b/beeep.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 var (
@@ -16,7 +17,7 @@ func pathAbs(path string) string {
 	var err error
 	var abs string
 
-	if path != "" {
+	if path != "" && strings.ContainsAny(path, "/\\.") {
 		abs, err = filepath.Abs(path)
 		if err != nil {
 			abs = path

--- a/beeep.go
+++ b/beeep.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"path/filepath"
 	"runtime"
-	"strings"
 )
 
 var (
@@ -17,7 +16,7 @@ func pathAbs(path string) string {
 	var err error
 	var abs string
 
-	if path != "" && strings.ContainsAny(path, "/\\.") {
+	if path != "" {
 		abs, err = filepath.Abs(path)
 		if err != nil {
 			abs = path

--- a/notify_unix.go
+++ b/notify_unix.go
@@ -13,7 +13,6 @@ import (
 func isAppIconRelative(appIcon string) bool {
 	for _, char := range appIcon {
 		if char == '\\' || char == '.' || char == '/' {
-			println(char)
 			return true
 		}
 	}

--- a/notify_unix.go
+++ b/notify_unix.go
@@ -10,11 +10,23 @@ import (
 	"github.com/godbus/dbus/v5"
 )
 
+func isAppIconRelative(appIcon string) bool {
+	for _, char := range appIcon {
+		if char == '\\' || char == '.' || char == '/' {
+			println(char)
+			return true
+		}
+	}
+	return false
+}
+
 // Notify sends desktop notification.
 //
 // On Linux it tries to send notification via D-Bus and it will fallback to `notify-send` binary.
 func Notify(title, message, appIcon string) error {
-	appIcon = pathAbs(appIcon)
+	if isAppIconRelative(appIcon) {
+		appIcon = pathAbs(appIcon)
+	}
 
 	cmd := func() error {
 		send, err := exec.LookPath("sw-notify-send")


### PR DESCRIPTION
### What?
Right now, we're always converting to an absolute path.

This means that if you're trying to create a notification with the system's `dialog-warning` icon, the notification's icon will end-up blank / missing.

### Why?
Instead of adding extra logic to figure out the absolute path of system icons, I think we should just be able to use the semantic name.

### Other possible solutions
If you don't like adding this check to the `pathAbs` function, I could simply move the check to the `notify_unix.go:17` file directly, as to not impact any other platforms.

### Calling a notification with the icon `dialog-warning`
Before PR:
![image](https://github.com/user-attachments/assets/f8f2ac43-87ed-4ad2-974d-46156d5344b4)

After PR:
![image](https://github.com/user-attachments/assets/11811b12-d8a1-45da-bff0-f58d0c43bac9)

> [!NOTE]
> I have not tested any other platforms, only linux with KDE plasma