### PR TITLE
switch from terminal-notifier to alerter

### DIFF
--- a/notify_darwin.go
+++ b/notify_darwin.go
@@ -2,11 +2,18 @@
 
 package beeep
 
+/*
+#include <libproc.h>
+*/
+import "C"
+
 import (
 	"fmt"
 	"image/png"
 	"os"
 	"os/exec"
+	"time"
+	"unsafe"
 
 	"github.com/jackmordaunt/icns/v3"
 )
@@ -14,7 +21,7 @@ import (
 // Notify sends desktop notification.
 // The icon can be string with a path to png file or png []byte data. Stock icon names can also be used where supported.
 //
-// On macOS, this will first try `terminal-notifier` and will fall back to AppleScript with `osascript`.
+// On macOS, this will first try `alerter` and will fall back to AppleScript with `osascript`.
 func Notify(title, message string, icon any) error {
 	return notify1(title, message, icon, false)
 }
@@ -30,9 +37,16 @@ func notify1(title, message string, icon any, urgent bool) error {
 	}
 
 	cmd1 := func() error {
-		cmd, err := exec.LookPath("terminal-notifier")
+		cmd, err := exec.LookPath("alerter")
 		if err != nil {
 			return err
+		}
+
+		var tmpFiles []string
+		cleanup := func() {
+			for _, f := range tmpFiles {
+				os.Remove(f)
+			}
 		}
 
 		var img string
@@ -42,13 +56,14 @@ func notify1(title, message string, icon any, urgent bool) error {
 			if err != nil {
 				return err
 			}
-			defer os.Remove(tmp1)
+			tmpFiles = append(tmpFiles, tmp1)
 
 			tmp2, err := pngToIcns(tmp1)
 			if err != nil {
+				cleanup()
 				return err
 			}
-			defer os.Remove(tmp2)
+			tmpFiles = append(tmpFiles, tmp2)
 
 			img = tmp2
 		} else {
@@ -56,20 +71,35 @@ func notify1(title, message string, icon any, urgent bool) error {
 			if err != nil {
 				return err
 			}
-			defer os.Remove(tmp)
-
+			tmpFiles = append(tmpFiles, tmp)
 			img = tmp
 		}
 
 		var args []string
 		if urgent {
-			args = []string{"-title", title, "-message", message, "-group", AppName, "-appIcon", img, "-sound", "default"}
+			args = []string{"--title", title, "--message", message, "--group", AppName, "--app-icon", img, "--sound", "default"}
 		} else {
-			args = []string{"-title", title, "-message", message, "-group", AppName, "-appIcon", img}
+			args = []string{"--title", title, "--message", message, "--group", AppName, "--app-icon", img}
 		}
+
 		c := exec.Command(cmd, args...)
 
-		return c.Run()
+		if err := c.Start(); err != nil {
+			cleanup()
+			return err
+		}
+
+		// Block until alerter has finished setup and entered its run loop,
+		// ensuring the icon temp file is not removed before alerter reads it.
+		waitUntilIdle(c.Process.Pid, 5*time.Second)
+
+		// Schedule cleanup for when alerter eventually exits.
+		go func() {
+			c.Wait()
+			cleanup()
+		}()
+
+		return nil
 	}
 
 	cmd2 := func() error {
@@ -84,6 +114,7 @@ func notify1(title, message string, icon any, urgent bool) error {
 		} else {
 			script = fmt.Sprintf("display notification %q with title %q", message, title)
 		}
+
 		cmd := exec.Command(osa, "-e", script)
 
 		return cmd.Run()
@@ -128,4 +159,48 @@ func pngToIcns(icon string) (string, error) {
 	}
 
 	return out, nil
+}
+
+func pidTaskInfo(pid int) (uint64, error) {
+	var info C.struct_proc_taskinfo
+
+	ret := C.proc_pidinfo(C.int(pid), C.PROC_PIDTASKINFO, 0, unsafe.Pointer(&info), C.int(unsafe.Sizeof(info)))
+	if ret <= 0 {
+		return 0, fmt.Errorf("proc_pidinfo failed")
+	}
+
+	return uint64(info.pti_total_user) + uint64(info.pti_total_system), nil
+}
+
+func waitUntilIdle(pid int, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	var prev uint64
+	seenActivity := false
+	stable := 0
+
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+
+		cur, err := pidTaskInfo(pid)
+		if err != nil {
+			return
+		}
+
+		if cur > 0 {
+			seenActivity = true
+		}
+
+		if seenActivity {
+			if cur == prev {
+				stable++
+				if stable >= 3 {
+					return
+				}
+			} else {
+				stable = 0
+			}
+		}
+
+		prev = cur
+	}
 }


### PR DESCRIPTION
This PR aims on switching from [terminal-notifier](https://github.com/julienXX/terminal-notifier) to [Alerter](https://github.com/vjeantet/alerter) with the change being fully transparent to users.

While there are not many changes in program arguments on `alerter` (aside from the single to double dash change) there's a distinct change in Alerter that makes the process hang until the notification quits. This renders our `c.Run()` golang call to `Wait` indefinitely and makes the command change to not be transparent to library users. Hence why `alerter` is now launched with `Start()` instead of `Run()`, so the library returns to the caller without blocking for the lifetime of the notification.

The main issue with letting the process launch on its own without any checkups is the existing app icon cleanup procedure, that erases the photo before the `alerter` process settles and starts idling with its notification drawn on the screen.

With the **aid from AI** there's two new private functions, `pidTaskInfo` and `waitUntilIdle`, that use low-level C functions to determine the `alerter` process is actually ready before returning.

More background on this [here](https://github.com/vjeantet/alerter/issues/70).

Resolves #75.
We can also consider this PR just as a PoC. I can convert it to draft if needed.

This PR builds and runs successfully on my macOS Tahoe 26.5 setup.

My testing code:
```go
package main

import (
	_ "embed"

	"github.com/gen2brain/beeep"
)

//go:embed info.png
var icon []byte

func main() {
	err := beeep.Notify("Title", "Message body", icon)
	if err != nil {
		panic(err)
	}

}
```

<img width="3680" height="2070" alt="scr" src="https://github.com/user-attachments/assets/1dea772c-1347-4c4a-b687-46ec0283cb16" />
